### PR TITLE
Fix RTSP connections with non-standard ports

### DIFF
--- a/src/core/DVRCamera.cpp
+++ b/src/core/DVRCamera.cpp
@@ -91,7 +91,7 @@ bool DVRCamera::parseXML(QXmlStreamReader &xml)
     url.setUserName(server()->username());
     url.setPassword(server()->password());
     url.setHost(server()->api->serverUrl().host());
-    url.setPort(7002);
+    url.setPort(server()->rtspPort());
     url.setPath(QString::fromLatin1("live/") + QString::number(d->uniqueID));
     d->streamUrl = url.toString().toLatin1();
     d->isLoaded = true;

--- a/src/core/DVRServer.h
+++ b/src/core/DVRServer.h
@@ -25,6 +25,7 @@ public:
 
     QString hostname() const;
     int serverPort() const;
+    int rtspPort() const;
     QString username() const;
     QString password() const;
 
@@ -83,6 +84,11 @@ inline int DVRServer::serverPort() const
     bool ok = false;
     int r = readSetting("port").toInt(&ok);
     return ok ? r : 7001;
+}
+
+inline int DVRServer::rtspPort() const
+{
+    return serverPort() + 1;
 }
 
 inline QString DVRServer::username() const


### PR DESCRIPTION
RTSP was hardcoded on port 7002; some users with NAT setups may have both web
and RTSP on ports other than the defaults. To support these users, without
having to expose both ports as separate, mostly redundant configuration
options, use one more than the server port for the RTSP port.

Feature #1122
