### PR TITLE
Fix LiveStreamItem texture deletion contexts

### DIFF
--- a/src/ui/liveview/LiveStreamItem.h
+++ b/src/ui/liveview/LiveStreamItem.h
@@ -6,6 +6,8 @@
 #include "core/MJpegStream.h"
 #include "core/LiveStream.h"
 
+class QGLContext;
+
 class LiveStreamItem : public QDeclarativeItem
 {
     Q_OBJECT
@@ -42,7 +44,11 @@ private:
     QSharedPointer<LiveStream> m_stream;
     bool m_useAdvancedGL;
     unsigned m_texId;
+    const QGLContext *m_texLastContext;
+    bool m_texInvalidate;
     const uchar *m_texDataPtr;
+
+    void clearTexture();
 };
 
 #endif // LIVESTREAMITEM_H

--- a/src/ui/liveview/LiveViewArea.cpp
+++ b/src/ui/liveview/LiveViewArea.cpp
@@ -38,6 +38,18 @@ LiveViewArea::LiveViewArea(QWidget *parent)
     Q_ASSERT(m_layout);
 }
 
+LiveViewArea::~LiveViewArea()
+{
+    /* For GL viewports, make that context current prior to clearing the scene
+     * to allow items a chance to clean up GL resources properly, though this is
+     * non-critical because the context destruction would implicitly free them.
+     * See LiveStreamItem. */
+    QGLWidget *gl = qobject_cast<QGLWidget*>(viewport());
+    if (gl)
+        gl->makeCurrent();
+    scene()->clear();
+}
+
 bool LiveViewArea::isHardwareAccelerated() const
 {
     return viewport()->inherits("QGLWidget");

--- a/src/ui/liveview/LiveViewArea.h
+++ b/src/ui/liveview/LiveViewArea.h
@@ -12,6 +12,7 @@ class LiveViewArea : public QDeclarativeView
 
 public:
     explicit LiveViewArea(QWidget *parent = 0);
+    virtual ~LiveViewArea();
 
     LiveViewLayout *layout() const { return m_layout; }
 


### PR DESCRIPTION
For the advanced GL case, a variety of paths in LiveStreamItem would try to
delete the texture without any attention to which (if any) OpenGL context was
current, which could result in deleting the wrong texture (bug #1118) or
potentially crashes.

Unfortunately, because there is no link between LiveStreamItem and the
viewport on which it's drawn, it's difficult to cover all of the situations
where textures need to be deleted. This code solves the problem by checking
the current context and setting a flag when unable to delete, and deleting it
later if possible, and careful checking of the paths where deletion can
happen.

There are potentially cleaner (or at least more clearly reliable) solutions
if LiveStreamItem makes assumptions about the scene it's in, and establishes
a direct relationship with the viewport. In that case, it could detect when
the context has been deleted, and would be able to make the context current
where necessary.
