### PR TITLE
Prompt for setup when connecting to unconfigured servers

### DIFF
--- a/src/core/DVRServer.h
+++ b/src/core/DVRServer.h
@@ -57,6 +57,8 @@ public slots:
 
 signals:
     void changed();
+    void devicesReady();
+
     void serverRemoved(DVRServer *server);
 
     void cameraAdded(const DVRCamera &camera);
@@ -70,6 +72,7 @@ private:
     QList<DVRCamera> m_cameras;
     QString m_displayName;
     QTimer m_refreshTimer;
+    bool devicesLoaded;
 };
 
 Q_DECLARE_METATYPE(DVRServer*)

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -54,6 +54,8 @@ private slots:
     void bandwidthModeChanged(int value);
     void eventsContextMenu(const QPoint &pos);
     void saveSettings();
+    void onServerAdded(DVRServer *server);
+    void serverDevicesLoaded();
 
 signals:
     void closing();


### PR DESCRIPTION
To assist with the first-time setup of servers, when connecting to a server
with no devices configured, prompt the user via a dialog to configure that
server, launching the configuration UI if accepted. This should help guide
the first time install process to some extent.

Workaround was necessary to prevent opening two modal windows at once, which
on OS X causes both to freeze up. As a result, the dialog may come up before
the setup wizard has been closed.

Feature #1065
