### PR TITLE
Fix occasional crash when closing video windows

### DIFF
--- a/src/video/GstSinkWidget.cpp
+++ b/src/video/GstSinkWidget.cpp
@@ -180,17 +180,20 @@ GstElement *GstSinkWidget::createElement()
 
 void GstSinkWidget::destroyElement()
 {
-    qDebug("gstreamer: Destroying sink widget");
+    if (m_element)
+    {
+        qDebug("gstreamer: Destroying sink widget");
 
-    /* Changing to NULL should always be synchronous; assertation should verify this. */
-    GstStateChangeReturn re = gst_element_set_state(GST_ELEMENT(m_element), GST_STATE_NULL);
-    Q_UNUSED(re);
-    Q_ASSERT(re == GST_STATE_CHANGE_SUCCESS);
+        /* Changing to NULL should always be synchronous; assertation should verify this. */
+        GstStateChangeReturn re = gst_element_set_state(GST_ELEMENT(m_element), GST_STATE_NULL);
+        Q_UNUSED(re);
+        Q_ASSERT(re == GST_STATE_CHANGE_SUCCESS);
 
-    /* At this point, it should not be possible to receive any more signals from the element,
-     * and the pipeline (if it still exists) is broken. */
-    g_object_unref(m_element);
-    m_element = 0;
+        /* At this point, it should not be possible to receive any more signals from the element,
+         * and the pipeline (if it still exists) is broken. */
+        g_object_unref(m_element);
+        m_element = 0;
+    }
 
     m_frameLock.lock();
     if (m_framePtr)


### PR DESCRIPTION
Regression caused by 2d0d1660. This would attempt to destroy the element in
some cases when there was no element allocated.
