### PR TITLE
Bug #1141: Connecting with a hostname fails with SSL error

### DIFF
--- a/src/core/BluecherryApp.cpp
+++ b/src/core/BluecherryApp.cpp
@@ -37,6 +37,11 @@ BluecherryApp::BluecherryApp()
     /* Don't use the system CAs to verify certificates */
     QSslConfiguration sslConfig = QSslConfiguration::defaultConfiguration();
     sslConfig.setCaCertificates(QList<QSslCertificate>());
+#if QT_VERSION >= 0x040800
+    /* SNI breaks connections (before sslError, even) when the hostname does
+     * not match the server. */
+    sslConfig.setSslOption(QSsl::SslOptionDisableServerNameIndication, true);
+#endif
     QSslConfiguration::setDefaultConfiguration(sslConfig);
 
     loadServers();


### PR DESCRIPTION
In Qt 4.8, support for the TLS SNI (server name indication) extension breaks
our SSL connections with hostnames, because the hostname we connect to might
have no relation to the server's actual hostname.

Disable SNI using Qt's option for this purpose to work around the issue.
