### PR TITLE
Fixed gstreamer for CMake linux

### DIFF
--- a/src/video/VideoPlayerBackend_gst.cpp
+++ b/src/video/VideoPlayerBackend_gst.cpp
@@ -77,11 +77,8 @@ bool VideoPlayerBackend::initGStreamer(QString *errorMessage)
         return false;
     }
 
-#if defined(Q_OS_LINUX) && !defined(GSTREAMER_PLUGINS)
-    /* Use the system installation of gstreamer on linux, where we don't need to
-     * explicitly load our plugins. */
-    return true;
-#endif
+    if (QString::fromLatin1(GSTREAMER_PLUGINS).isEmpty())
+        return true;
 
 #ifdef Q_OS_WIN
 #define EXT ".dll"


### PR DESCRIPTION
GSTREAMER_PLUGINS are now always defined, but sometimes empty

Signed-off-by: Rafał Malinowski rafal.malinowski@corp.bluecherry.net
