### PR TITLE
308 Fix Documentation link in Help menu

### DIFF
--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -548,7 +548,7 @@ void MainWindow::openAbout()
 
 void MainWindow::openDocumentation()
 {
-    QUrl url(QLatin1String("http://docs.bluecherrydvr.com/collection/13-version-2-user-manual"));
+    QUrl url(QLatin1String("http://docs.bluecherrydvr.com/en/latest/#"));
     bool ok = QDesktopServices::openUrl(url);
     if (!ok)
         QMessageBox::critical(this, tr("Error"), tr("An error occurred while opening %1").arg(url.toString()));


### PR DESCRIPTION
Fixes the incorrect link from the Help -> Documentation menu path to point towards latest documentation website.