### PR TITLE
310 - Fix Support link in Help menu

### DIFF
--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -564,7 +564,7 @@ void MainWindow::openIdeas()
 
 void MainWindow::openSupport()
 {
-    QUrl url(QLatin1String("http://community.bluecherrydvr.com/topic/add"));
+    QUrl url(QLatin1String("https://docs.bluecherrydvr.com/"));
     bool ok = QDesktopServices::openUrl(url);
     if (!ok)
         QMessageBox::critical(this, tr("Error"), tr("An error occurred while opening %1").arg(url.toString()));


### PR DESCRIPTION
Updates the URL associated with "Bluecherry support" in the Help menu.