### PR TITLE
Fix drag&drop event adding camera

### DIFF
--- a/src/ui/liveview/LiveViewWindow.h
+++ b/src/ui/liveview/LiveViewWindow.h
@@ -56,6 +56,7 @@ public:
     QWidget *topWidget() { return m_topWidget; }
     QWidget *fullScreenWidget() { return m_fsSetWindow.data(); }
     void addCamera(DVRCamera *camera);
+    void addCamera_dragdrop(QDropEvent *event, DVRCamera *camera);
     static int maxRows();
     static int maxColumns();
     void setGridSize(int rows, int columns);


### PR DESCRIPTION
I tested your new implementing and there are a few minor bugs.
1. setPixmap image with currentFrame when the drag camera on LiveViewWindow layout
2. drag&drop event for adding camera is auto camera index with grid

Here is my fix:
1. scale size change image with widget
2. add camera at drop position